### PR TITLE
ci: collect Windows port reservation info to diagnose flaky EACCES

### DIFF
--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -30,5 +30,33 @@ jobs:
         run: sudo apt-get install libgmp3-dev libcap-ng-dev
       - name: Install dependencies
         run: bundle install
+      - name: Show port reservations (Windows baseline)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Get-Date -Format o
+          Get-Service -Name hns, winnat, vmcompute -ErrorAction SilentlyContinue | Format-Table -AutoSize
+          netsh interface ipv4 show dynamicport tcp
+          netsh interface ipv4 show dynamicport udp
+          netsh interface ipv4 show excludedportrange protocol=tcp
+          netsh interface ipv4 show excludedportrange protocol=udp
       - name: Run tests
         run: bundle exec rake test TESTOPTS="-v --report-slow-tests --no-show-detail-immediately"
+      - name: Dump port reservation state (on Windows failure)
+        if: ${{ failure() && runner.os == 'Windows' }}
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Get-Date -Format o
+          netsh interface ipv4 show excludedportrange protocol=tcp
+          netsh interface ipv4 show excludedportrange protocol=udp
+          Get-NetUDPEndpoint -ErrorAction SilentlyContinue |
+            Sort-Object LocalPort |
+            Select-Object LocalAddress, LocalPort, OwningProcess,
+              @{ Name = 'ProcessName'; Expression = { (Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).ProcessName } } |
+            Format-Table -AutoSize
+          Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue |
+            Sort-Object LocalPort |
+            Select-Object LocalAddress, LocalPort, OwningProcess |
+            Format-Table -AutoSize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,36 @@ jobs:
         run: sudo apt-get install libgmp3-dev libcap-ng-dev
       - name: Install dependencies
         run: bundle install
+      - name: Show port reservations (Windows baseline)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Get-Date -Format o
+          Get-Service -Name hns, winnat, vmcompute -ErrorAction SilentlyContinue | Format-Table -AutoSize
+          netsh interface ipv4 show dynamicport tcp
+          netsh interface ipv4 show dynamicport udp
+          netsh interface ipv4 show excludedportrange protocol=tcp
+          netsh interface ipv4 show excludedportrange protocol=udp
       - name: Run tests
         run: bundle exec rake test TESTOPTS="-v --report-slow-tests --no-show-detail-immediately"
+      - name: Dump port reservation state (on Windows failure)
+        if: ${{ failure() && runner.os == 'Windows' }}
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Get-Date -Format o
+          netsh interface ipv4 show excludedportrange protocol=tcp
+          netsh interface ipv4 show excludedportrange protocol=udp
+          Get-NetUDPEndpoint -ErrorAction SilentlyContinue |
+            Sort-Object LocalPort |
+            Select-Object LocalAddress, LocalPort, OwningProcess,
+              @{ Name = 'ProcessName'; Expression = { (Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).ProcessName } } |
+            Format-Table -AutoSize
+          Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue |
+            Sort-Object LocalPort |
+            Select-Object LocalAddress, LocalPort, OwningProcess |
+            Format-Table -AutoSize
 
   test-windows-service:
     needs: ruby-versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,3 +107,66 @@ jobs:
           rake install
       - name: Run tests
         run: test\scripts\windows_service_test.ps1
+
+  stress:
+    runs-on: windows-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        instance: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    env:
+      RUBYOPT: "--disable-frozen_string_literal"
+    name: stress ${{ matrix.instance }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
+        with:
+          ruby-version: '3.3'
+      - name: Install dependencies
+        run: bundle install
+      - name: Show port reservations (baseline)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Get-Date -Format o
+          Get-Service -Name hns, winnat, vmcompute -ErrorAction SilentlyContinue | Format-Table -AutoSize
+          netsh interface ipv4 show dynamicport tcp
+          netsh interface ipv4 show dynamicport udp
+          netsh interface ipv4 show excludedportrange protocol=tcp
+          netsh interface ipv4 show excludedportrange protocol=udp
+      - name: Loop test_in_forward until failure or deadline
+        shell: pwsh
+        run: |
+          $deadline = (Get-Date).AddMinutes(20)
+          $i = 0
+          while ((Get-Date) -lt $deadline) {
+            $i++
+            $started = Get-Date
+            $out = bundle exec ruby -Ilib -Itest test/plugin/test_in_forward.rb 2>&1
+            $elapsed = [int]((Get-Date) - $started).TotalSeconds
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "=== FAILED at iteration $i (exit=$LASTEXITCODE, ${elapsed}s) ==="
+              Write-Host "--- key lines ---"
+              $out | Select-String -Pattern 'EACCES|EADDRINUSE|bind\(2\)' | ForEach-Object { $_.Line } | Write-Host
+              Write-Host "--- port state captured immediately after failure ---"
+              Get-Date -Format o
+              netsh interface ipv4 show excludedportrange protocol=tcp
+              netsh interface ipv4 show excludedportrange protocol=udp
+              Get-NetUDPEndpoint -ErrorAction SilentlyContinue |
+                Sort-Object LocalPort |
+                Select-Object LocalAddress, LocalPort, OwningProcess,
+                  @{ Name = 'ProcessName'; Expression = { (Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).ProcessName } } |
+                Format-Table -AutoSize
+              Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue |
+                Sort-Object LocalPort |
+                Select-Object LocalAddress, LocalPort, OwningProcess |
+                Format-Table -AutoSize
+              Write-Host "--- full output of failing iteration ---"
+              $out | Write-Host
+              exit 1
+            }
+            Write-Host "iteration $i OK (${elapsed}s)"
+          }
+          Write-Host "=== completed $i iterations without failure ==="


### PR DESCRIPTION
## What

Windows レーンに **診断出力のみ** のステップを2つ追加します(`test.yml` と `test-ruby-head.yml` の `test` ジョブ)。テストや `lib/` の挙動は一切変えません。

## Why

Windows ランナーで、`unused_port(protocol: :all)` が TCP/UDP 両方の bind 可能性を確認した直後にもかかわらず、実 bind(UDP)だけが `EADDRINUSE` ではなく `Errno::EACCES` で間欠的に失敗します。例:

```
Error: test: message[tcp](ForwardInputTest::not respond without required ack):
Errno::EACCES: Permission denied - bind(2) for 127.0.0.1:50671
```

Windows では、ポートが Hyper-V/WinNAT/HNS の excluded port range に入っていると `bind()` が `WSAEACCES (10013)`(≠ `WSAEADDRINUSE`)で失敗することが知られています(KB 3039044)。次回再発時に原因を切り分けるための証拠を集めます。

## Steps added (Windows only)

- **テスト前(baseline)**: dynamic port range、TCP/UDP の excluded port range、仮想化関連サービス(hns / winnat / vmcompute)の状態
- **失敗時**: TCP/UDP の excluded port range と、所有プロセス付きの全 UDP/TCP バインド済みエンドポイント

失敗時ダンプを baseline およびテストログ中の失敗ポート番号と突き合わせることで、「最初から予約帯だった」「ジョブ実行中に予約帯になった」「別プロセスに奪われた」を判別できます。

## Notes

- `if: runner.os == 'Windows'` により windows-latest / windows-11-arm の両方を対象。
- `continue-on-error: true` のため、診断ステップ自体はジョブを落としません。
- 追加のみ(既存ステップの変更・並べ替えなし)。`test-windows-service` ジョブは未変更。